### PR TITLE
Added capability to run the CompileCommand

### DIFF
--- a/src/Command/CompileCommand.php
+++ b/src/Command/CompileCommand.php
@@ -15,6 +15,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class CompileCommand extends Command
 {
+    public const EXIT_MESSAGE = 'Compile command complete';
+
     /**
      * @var PipelineBundler
      */
@@ -42,5 +44,10 @@ final class CompileCommand extends Command
         $writer = new FileWriter($this->config->getProjectRoot());
 
         $this->bundler->execute($reader, $writer);
+
+        // Write this exit message to denote that we are done
+        // Is used in a functional way to prevent defunct processes
+        // https://github.com/symfony/symfony/issues/12097#issuecomment-343145050
+        $output->writeln(self::EXIT_MESSAGE);
     }
 }

--- a/src/Command/CompileCommandRunner.php
+++ b/src/Command/CompileCommandRunner.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+namespace Hostnet\Bundle\AssetBundle\Command;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class CompileCommandRunner
+{
+    /**
+     * Private by design because this is class only has static members
+     */
+    private function __construct()
+    {
+    }
+
+    public static function runCommand(
+        string $console = 'bin/console',
+        int $verbosity = OutputInterface::VERBOSITY_NORMAL
+    ) {
+        switch ($verbosity) {
+            case OutputInterface::VERBOSITY_DEBUG:
+                $vvv = ' -vvv';
+                break;
+            case OutputInterface::VERBOSITY_VERY_VERBOSE:
+                $vvv = ' -vv';
+                break;
+            case OutputInterface::VERBOSITY_VERBOSE:
+                $vvv = ' -v';
+                break;
+            default:
+                $vvv = '';
+        }
+        $cmd = $console . ' assets:compile --env=prod' . $vvv;
+
+        $resource = proc_open($cmd, [1 => ['pipe', 'w']], $pipes);
+
+        if (! is_resource($resource)) {
+            throw new \RuntimeException('Expected proc_open to create a resource');
+        }
+        // $pipes now looks like this:
+        // 1 => readable handle connected to child stdout
+
+        while ($line = fgets($pipes[1])) {
+            if ($line === CompileCommand::EXIT_MESSAGE . PHP_EOL) {
+                break;
+            }
+            echo '> ' . $line;
+        }
+
+        // First close pipe to prevent deadlock
+        fclose($pipes[1]);
+        proc_terminate($resource);
+    }
+}

--- a/test/Command/CompileCommandRunnerTest.php
+++ b/test/Command/CompileCommandRunnerTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+declare(strict_types=1);
+namespace Hostnet\Bundle\AssetBundle\Command;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @covers \Hostnet\Bundle\AssetBundle\Command\CompileCommandRunner
+ */
+class CompileCommandRunnerTest extends TestCase
+{
+    /**
+     * @dataProvider runCommandProvider
+     */
+    public function testRunCommand(int $verbosity, string $expected)
+    {
+        $between = ' assets:compile --env=prod';
+        $this->expectOutputString('> ' . CompileCommand::EXIT_MESSAGE . $between . PHP_EOL);
+        CompileCommandRunner::runCommand('echo ' . CompileCommand::EXIT_MESSAGE);
+    }
+
+    public function runCommandProvider()
+    {
+        return [
+            [OutputInterface::VERBOSITY_NORMAL, ''],
+            [OutputInterface::VERBOSITY_VERBOSE, '-v'],
+            [OutputInterface::VERBOSITY_VERY_VERBOSE, '-vv'],
+            [OutputInterface::VERBOSITY_DEBUG, '-vvv'],
+        ];
+    }
+}

--- a/test/Command/CompileCommandTest.php
+++ b/test/Command/CompileCommandTest.php
@@ -12,7 +12,7 @@ use Hostnet\Component\Resolver\FileSystem\WriterInterface;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @covers \Hostnet\Bundle\AssetBundle\Command\CompileCommand
@@ -42,10 +42,15 @@ class CompileCommandTest extends TestCase
     {
         $this->config->getProjectRoot()->willReturn(__DIR__);
 
+        $output = $this->prophesize(OutputInterface::class);
+
         $this->bundler
             ->execute(Argument::type(ReaderInterface::class), Argument::type(WriterInterface::class))
-            ->shouldBeCalled();
+            ->shouldBeCalled()
+            ->will(function () use ($output) {
+                $output->writeln(CompileCommand::EXIT_MESSAGE)->shouldBeCalled();
+            });
 
-        $this->compile_command->run(new ArrayInput([]), new NullOutput());
+        $this->compile_command->run(new ArrayInput([]), $output->reveal());
     }
 }


### PR DESCRIPTION
Adds possibility to be able to run the command to build the prod assets, for instance via composer.

There is a risk on getting left with a defunct process when
- spawning a background process
- from a php process (`bin/console assets:compile`)
- which was started from a php process (`composer install`)

Also see this bug: https://github.com/symfony/symfony/issues/12097#issuecomment-343145050

The 'fix' for this problem was to let the `assets:compile` process let it known to it's parent process that it is done. After that it is terminated with signal 15 (a bit nicer than 9).