### PR TITLE
Made plugin check for interface instead of hardcoded list

### DIFF
--- a/src/DependencyInjection/HostnetAssetExtension.php
+++ b/src/DependencyInjection/HostnetAssetExtension.php
@@ -21,6 +21,7 @@ use Hostnet\Component\Resolver\Plugin\LessPlugin;
 use Hostnet\Component\Resolver\Plugin\MinifyPlugin;
 use Hostnet\Component\Resolver\Plugin\PluginActivator;
 use Hostnet\Component\Resolver\Plugin\PluginApi;
+use Hostnet\Component\Resolver\Plugin\PluginInterface;
 use Hostnet\Component\Resolver\Plugin\TsPlugin;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -47,18 +48,18 @@ final class HostnetAssetExtension extends Extension
 
         $container->setDefinition('hostnet_asset.node.executable', $node_executable);
 
-        $plugins  = [];
-        $built_in = [CorePlugin::class, TsPlugin::class, LessPlugin::class, AngularPlugin::class, MinifyPlugin::class];
+        $plugins = [];
         foreach ($config['plugins'] as $name => $is_enabled) {
             if (! $is_enabled) {
                 continue;
             }
 
-            if (! in_array($name, $built_in)) {
-                // Note: no code written yet to allow custom plugins
-                // So long as someone implements the PluginInterface
-                // Just add it to the $plugins array & go :)
-                throw new InvalidConfigurationException(sprintf('Unknown plugin %s.', $name));
+            if (! is_subclass_of($name, PluginInterface::class)) {
+                throw new InvalidConfigurationException(sprintf(
+                    'Class %s should implement %s.',
+                    $name,
+                    PluginInterface::class
+                ));
             }
 
             $plugins[] = $this->configurePlugin($name, $container);

--- a/test/DependencyInjection/HostnetAssetExtensionTest.php
+++ b/test/DependencyInjection/HostnetAssetExtensionTest.php
@@ -358,7 +358,7 @@ class HostnetAssetExtensionTest extends TestCase
 
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Unknown plugin stdClass.
+     * @expectedExceptionMessage Class stdClass should implement Hostnet\Component\Resolver\Plugin\PluginInterface.
      */
     public function testBuildNonPlugin()
     {
@@ -382,10 +382,6 @@ class HostnetAssetExtensionTest extends TestCase
         $container->compile();
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Unknown plugin Hostnet\Bundle\AssetBundle\DependencyInjection\MockPlugin.
-     */
     public function testBuildNonBuiltin()
     {
         $container = new ContainerBuilder();
@@ -405,6 +401,14 @@ class HostnetAssetExtensionTest extends TestCase
             ]
         ]], $container);
 
+        // make the config public
+        $container->getDefinition('hostnet_asset.config')->setPublic(true);
+
         $container->compile();
+
+        $plugins = $container->get('hostnet_asset.config')->getPlugins();
+
+        self::assertCount(1, $plugins);
+        self::assertInstanceOf(MockPlugin::class, $plugins[0]);
     }
 }

--- a/test/DependencyInjection/MockPlugin.php
+++ b/test/DependencyInjection/MockPlugin.php
@@ -10,7 +10,6 @@ use Hostnet\Component\Resolver\Plugin\PluginInterface;
 
 class MockPlugin implements PluginInterface
 {
-
     public function activate(PluginApi $plugin_api): void
     {
     }


### PR DESCRIPTION
Made plugin check for interface instead of hardcoded list. So any plugin can now be added as log as it implements the `Hostnet\Component\Resolver\Plugin\PluginInterface`.