### PR TITLE
Added asset debug command

### DIFF
--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -125,7 +125,7 @@ class DebugCommand extends Command
 
     private function filesize(string $file)
     {
-        $bytes = filesize($file);
+        $bytes = filesize($this->config->getProjectRoot() . DIRECTORY_SEPARATOR . $file);
         $sizes = 'BKMGTP';
         $factor = (int) floor((strlen((string) $bytes) - 1) / 3);
 

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -1,0 +1,162 @@
+<?php
+declare(strict_types=1);
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+namespace Hostnet\Bundle\AssetBundle\Command;
+
+use Hostnet\Component\Resolver\Bundler\Asset;
+use Hostnet\Component\Resolver\Bundler\EntryPoint;
+use Hostnet\Component\Resolver\Config\ConfigInterface;
+use Hostnet\Component\Resolver\File;
+use Hostnet\Component\Resolver\Import\ImportFinderInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DebugCommand extends Command
+{
+    private $config;
+    private $finder;
+
+    public function __construct(ConfigInterface $config, ImportFinderInterface $finder)
+    {
+        parent::__construct('debug:asset');
+
+        $this->config = $config;
+        $this->finder = $finder;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Displays asset information.')
+            ->addArgument('file');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($input->getArgument('file')) {
+            $this->checkFile($output, $input->getArgument('file'));
+        } else {
+            $this->printAll($output);
+        }
+    }
+
+    private function checkFile(OutputInterface $output, string $file)
+    {
+        $entry_points = $this->config->getEntryPoints();
+        $assets       = $this->config->getAssetFiles();
+        $source_dir   = (!empty($this->config->getSourceRoot()) ? $this->config->getSourceRoot() . '/' : '');
+        $output_dir   = $this->config->getOutputFolder();
+
+        $type = 'Unknown';
+
+        foreach ($entry_points as $asset) {
+            if ($source_dir . $asset === $file) {
+                $type = 'Entry Point';
+                break;
+            }
+        }
+        foreach ($assets as $asset) {
+            if ($source_dir . $asset === $file) {
+                $type = 'Asset';
+                break;
+            }
+        }
+
+        $output->writeln('File info:');
+        $output->writeln('  - Root: ' . $file);
+        $output->writeln('  - Type: ' . $type);
+        $output->writeln('  - Size: ' . $this->filesize($file));
+        $output->writeln('');
+
+        $file_obj = new File($file);
+
+        if ($type === 'Entry Point') {
+            $entry_points = new EntryPoint($this->finder->all($file_obj));
+
+            $output->writeln('Bundle bundled files: (' . $entry_points->getBundleFile($output_dir)->path . ')');
+
+            foreach ($entry_points->getBundleFiles() as $dep) {
+                $output->writeln('  - ' . $dep->getFile()->getName());
+            }
+            if (\count($entry_points->getBundleFiles()) === 0) {
+                $output->writeln('  - None');
+            }
+
+            $output->writeln('Vendor bundled files: (' . $entry_points->getVendorFile($output_dir)->path . ')');
+
+            foreach ($entry_points->getVendorFiles() as $dep) {
+                $output->writeln('  - ' . $dep->getFile()->getName());
+            }
+            if (\count($entry_points->getVendorFiles()) === 0) {
+                $output->writeln('  - None');
+            }
+        } else {
+            $root = new Asset($this->finder->all($file_obj), '.js');
+
+            $output->writeln('Bundled files:');
+
+            foreach ($root->getFiles() as $dep) {
+                $output->writeln('  - ' . $dep->getFile()->getName());
+            }
+            if (\count($root->getFiles()) === 0) {
+                $output->writeln('  - None');
+            }
+        }
+
+        $output->writeln('');
+        $output->writeln('Dependency tree:');
+        $this->printDependencyTree($output, $file_obj);
+    }
+
+    private function printDependencyTree(OutputInterface $output, File $file, int $dept = 0)
+    {
+        $deps = $this->finder->all($file);
+
+        foreach ($deps->getChildren() as $child) {
+            $child_file = $child->getFile();
+            $output->writeln(str_repeat('  ', $dept) . '  - ' . $child_file->getName());
+
+            $this->printDependencyTree($output, $child_file, $dept + 1);
+        }
+    }
+
+    private function filesize(string $file)
+    {
+        $bytes = filesize($file);
+        $sizes = 'BKMGTP';
+        $factor = (int) floor((strlen((string) $bytes) - 1) / 3);
+
+        return sprintf('%.2f', $bytes / (1024 ** $factor)) . @$sizes[$factor];
+    }
+
+    private function printAll(OutputInterface $output)
+    {
+        $entry_points = $this->config->getEntryPoints();
+        $assets       = $this->config->getAssetFiles();
+        $source_dir   = (!empty($this->config->getSourceRoot()) ? $this->config->getSourceRoot() . '/' : '');
+
+        $output->writeln('Entry points:');
+
+        if (\count($entry_points) === 0) {
+            $output->writeln('  - None');
+        }
+
+        foreach ($entry_points as $entry_point) {
+            $output->writeln('  - ' . $source_dir . $entry_point);
+        }
+
+        $output->writeln('');
+        $output->writeln('Asset files:');
+
+        if (\count($assets) === 0) {
+            $output->writeln('  - None');
+        }
+
+        foreach ($assets as $asset) {
+            $output->writeln('  - ' . $source_dir . $asset);
+        }
+    }
+}

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -111,15 +111,15 @@ class DebugCommand extends Command
         $this->printDependencyTree($output, $file_obj);
     }
 
-    private function printDependencyTree(OutputInterface $output, File $file, int $dept = 0)
+    private function printDependencyTree(OutputInterface $output, File $file, int $depth = 0)
     {
         $deps = $this->finder->all($file);
 
         foreach ($deps->getChildren() as $child) {
             $child_file = $child->getFile();
-            $output->writeln(str_repeat('  ', $dept) . '  - ' . $child_file->getName());
+            $output->writeln(str_repeat('  ', $depth) . '  - ' . $child_file->getName());
 
-            $this->printDependencyTree($output, $child_file, $dept + 1);
+            $this->printDependencyTree($output, $child_file, $depth + 1);
         }
     }
 

--- a/src/DependencyInjection/HostnetAssetExtension.php
+++ b/src/DependencyInjection/HostnetAssetExtension.php
@@ -6,6 +6,7 @@ declare(strict_types = 1);
 namespace Hostnet\Bundle\AssetBundle\DependencyInjection;
 
 use Hostnet\Bundle\AssetBundle\Command\CompileCommand;
+use Hostnet\Bundle\AssetBundle\Command\DebugCommand;
 use Hostnet\Bundle\AssetBundle\EventListener\AssetsChangeListener;
 use Hostnet\Bundle\AssetBundle\Twig\AssetExtension;
 use Hostnet\Component\Resolver\Bundler\Pipeline\ContentPipeline;
@@ -168,6 +169,17 @@ final class HostnetAssetExtension extends Extension
             ->setPublic(false);
 
         $container->setDefinition('hostnet_asset.command.compile', $compile);
+
+        if ($container->getParameter('kernel.debug')) {
+            $debug = (new Definition(DebugCommand::class, [
+                new Reference('hostnet_asset.config'),
+                new Reference('hostnet_asset.import_finder'),
+            ]))
+                ->addTag('console.command')
+                ->setPublic(false);
+
+            $container->setDefinition('hostnet_asset.command.debug', $debug);
+        }
     }
 
     private function configureEventListeners(ContainerBuilder $container)

--- a/test/Command/DebugCommandTest.php
+++ b/test/Command/DebugCommandTest.php
@@ -40,8 +40,8 @@ class DebugCommandTest extends TestCase
 
     public function testExecute()
     {
-        $this->config->getProjectRoot()->willReturn(__DIR__);
-        $this->config->getSourceRoot()->willReturn('src');
+        $this->config->getProjectRoot()->willReturn(dirname(__DIR__));
+        $this->config->getSourceRoot()->willReturn(basename(__DIR__));
         $this->config->getEntryPoints()->willReturn([basename(__FILE__)]);
         $this->config->getAssetFiles()->willReturn([]);
 
@@ -54,14 +54,14 @@ class DebugCommandTest extends TestCase
 
     public function testExecuteWithEntryPoint()
     {
-        $this->config->getProjectRoot()->willReturn(__DIR__);
-        $this->config->getSourceRoot()->willReturn('');
+        $this->config->getProjectRoot()->willReturn(dirname(__DIR__));
+        $this->config->getSourceRoot()->willReturn(basename(__DIR__));
         $this->config->getEntryPoints()->willReturn([basename(__FILE__)]);
         $this->config->getAssetFiles()->willReturn([]);
         $this->config->getOutputFolder()->willReturn('dev');
 
-        $file = new File(basename(__FILE__));
-        $dep = new File('expected.output.txt');
+        $file = new File(basename(__DIR__) . '/' . basename(__FILE__));
+        $dep = new File(basename(__DIR__) . '/expected.output.txt');
         $root = new RootFile($file);
         $root->addChild(new Dependency($dep));
 
@@ -70,21 +70,21 @@ class DebugCommandTest extends TestCase
 
         $output = new BufferedOutput();
 
-        $this->compile_command->run(new ArrayInput(['file' => basename(__FILE__)]), $output);
+        $this->compile_command->run(new ArrayInput(['file' => basename(__DIR__) . '/' . basename(__FILE__)]), $output);
 
         self::assertStringEqualsFile(__DIR__ . '/expected-entry_point.output.txt', $output->fetch());
     }
 
     public function testExecuteWithAsset()
     {
-        $this->config->getProjectRoot()->willReturn(__DIR__);
-        $this->config->getSourceRoot()->willReturn('');
+        $this->config->getProjectRoot()->willReturn(dirname(__DIR__));
+        $this->config->getSourceRoot()->willReturn(basename(__DIR__));
         $this->config->getEntryPoints()->willReturn([]);
         $this->config->getAssetFiles()->willReturn([basename(__FILE__)]);
         $this->config->getOutputFolder()->willReturn('dev');
 
-        $file = new File(basename(__FILE__));
-        $dep = new File('expected.output.txt');
+        $file = new File(basename(__DIR__) . '/' . basename(__FILE__));
+        $dep = new File(basename(__DIR__) . '/expected.output.txt');
         $root = new RootFile($file);
         $root->addChild(new Dependency($dep));
 
@@ -93,7 +93,7 @@ class DebugCommandTest extends TestCase
 
         $output = new BufferedOutput();
 
-        $this->compile_command->run(new ArrayInput(['file' => basename(__FILE__)]), $output);
+        $this->compile_command->run(new ArrayInput(['file' => basename(__DIR__) . '/' . basename(__FILE__)]), $output);
 
         self::assertStringEqualsFile(__DIR__ . '/expected-asset.output.txt', $output->fetch());
     }

--- a/test/Command/DebugCommandTest.php
+++ b/test/Command/DebugCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @copyright 2017 Hostnet B.V.
+ */
+declare(strict_types=1);
+namespace Hostnet\Bundle\AssetBundle\Command;
+
+use Hostnet\Component\Resolver\Config\ConfigInterface;
+use Hostnet\Component\Resolver\File;
+use Hostnet\Component\Resolver\Import\Dependency;
+use Hostnet\Component\Resolver\Import\ImportFinderInterface;
+use Hostnet\Component\Resolver\Import\RootFile;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * @covers \Hostnet\Bundle\AssetBundle\Command\DebugCommand
+ */
+class DebugCommandTest extends TestCase
+{
+    private $config;
+    private $finder;
+
+    /**
+     * @var CompileCommand
+     */
+    private $compile_command;
+
+    protected function setUp()
+    {
+        $this->config  = $this->prophesize(ConfigInterface::class);
+        $this->finder = $this->prophesize(ImportFinderInterface::class);
+
+        $this->compile_command = new DebugCommand(
+            $this->config->reveal(),
+            $this->finder->reveal()
+        );
+    }
+
+    public function testExecute()
+    {
+        $this->config->getProjectRoot()->willReturn(__DIR__);
+        $this->config->getSourceRoot()->willReturn('src');
+        $this->config->getEntryPoints()->willReturn([basename(__FILE__)]);
+        $this->config->getAssetFiles()->willReturn([]);
+
+        $output = new BufferedOutput();
+
+        $this->compile_command->run(new ArrayInput([]), $output);
+
+        self::assertStringEqualsFile(__DIR__ . '/expected.output.txt', $output->fetch());
+    }
+
+    public function testExecuteWithEntryPoint()
+    {
+        $this->config->getProjectRoot()->willReturn(__DIR__);
+        $this->config->getSourceRoot()->willReturn('');
+        $this->config->getEntryPoints()->willReturn([basename(__FILE__)]);
+        $this->config->getAssetFiles()->willReturn([]);
+        $this->config->getOutputFolder()->willReturn('dev');
+
+        $file = new File(basename(__FILE__));
+        $dep = new File('expected.output.txt');
+        $root = new RootFile($file);
+        $root->addChild(new Dependency($dep));
+
+        $this->finder->all($file)->willReturn($root);
+        $this->finder->all($dep)->willReturn(new RootFile($dep));
+
+        $output = new BufferedOutput();
+
+        $this->compile_command->run(new ArrayInput(['file' => basename(__FILE__)]), $output);
+
+        self::assertStringEqualsFile(__DIR__ . '/expected-entry_point.output.txt', $output->fetch());
+    }
+
+    public function testExecuteWithAsset()
+    {
+        $this->config->getProjectRoot()->willReturn(__DIR__);
+        $this->config->getSourceRoot()->willReturn('');
+        $this->config->getEntryPoints()->willReturn([]);
+        $this->config->getAssetFiles()->willReturn([basename(__FILE__)]);
+        $this->config->getOutputFolder()->willReturn('dev');
+
+        $file = new File(basename(__FILE__));
+        $dep = new File('expected.output.txt');
+        $root = new RootFile($file);
+        $root->addChild(new Dependency($dep));
+
+        $this->finder->all($file)->willReturn($root);
+        $this->finder->all($dep)->willReturn(new RootFile($dep));
+
+        $output = new BufferedOutput();
+
+        $this->compile_command->run(new ArrayInput(['file' => basename(__FILE__)]), $output);
+
+        self::assertStringEqualsFile(__DIR__ . '/expected-asset.output.txt', $output->fetch());
+    }
+}

--- a/test/Command/DebugCommandTest.php
+++ b/test/Command/DebugCommandTest.php
@@ -72,7 +72,11 @@ class DebugCommandTest extends TestCase
 
         $this->compile_command->run(new ArrayInput(['file' => basename(__DIR__) . '/' . basename(__FILE__)]), $output);
 
-        self::assertStringEqualsFile(__DIR__ . '/expected-entry_point.output.txt', $output->fetch());
+        self::assertSame(str_replace(
+            '{{SIZE}}',
+            $this->filesize(__FILE__),
+            file_get_contents(__DIR__ . '/expected-entry_point.output.txt')
+        ), $output->fetch());
     }
 
     public function testExecuteWithAsset()
@@ -95,6 +99,19 @@ class DebugCommandTest extends TestCase
 
         $this->compile_command->run(new ArrayInput(['file' => basename(__DIR__) . '/' . basename(__FILE__)]), $output);
 
-        self::assertStringEqualsFile(__DIR__ . '/expected-asset.output.txt', $output->fetch());
+        self::assertSame(str_replace(
+            '{{SIZE}}',
+            $this->filesize(__FILE__),
+            file_get_contents(__DIR__ . '/expected-asset.output.txt')
+        ), $output->fetch());
+    }
+
+    private function filesize(string $file)
+    {
+        $bytes = filesize($file);
+        $sizes = 'BKMGTP';
+        $factor = (int) floor((strlen((string) $bytes) - 1) / 3);
+
+        return sprintf('%.2f', $bytes / (1024 ** $factor)) . @$sizes[$factor];
     }
 }

--- a/test/Command/expected-asset.output.txt
+++ b/test/Command/expected-asset.output.txt
@@ -1,7 +1,7 @@
 File info:
   - Root: Command/DebugCommandTest.php
   - Type: Asset
-  - Size: 3.59K
+  - Size: {{SIZE}}
 
 Bundled files:
   - Command/DebugCommandTest.php

--- a/test/Command/expected-asset.output.txt
+++ b/test/Command/expected-asset.output.txt
@@ -1,11 +1,11 @@
 File info:
-  - Root: DebugCommandTest.php
+  - Root: Command/DebugCommandTest.php
   - Type: Asset
-  - Size: 3.38K
+  - Size: 3.59K
 
 Bundled files:
-  - DebugCommandTest.php
-  - expected.output.txt
+  - Command/DebugCommandTest.php
+  - Command/expected.output.txt
 
 Dependency tree:
-  - expected.output.txt
+  - Command/expected.output.txt

--- a/test/Command/expected-asset.output.txt
+++ b/test/Command/expected-asset.output.txt
@@ -1,0 +1,11 @@
+File info:
+  - Root: DebugCommandTest.php
+  - Type: Asset
+  - Size: 3.38K
+
+Bundled files:
+  - DebugCommandTest.php
+  - expected.output.txt
+
+Dependency tree:
+  - expected.output.txt

--- a/test/Command/expected-entry_point.output.txt
+++ b/test/Command/expected-entry_point.output.txt
@@ -1,7 +1,7 @@
 File info:
   - Root: Command/DebugCommandTest.php
   - Type: Entry Point
-  - Size: 3.59K
+  - Size: {{SIZE}}
 
 Bundle bundled files: (dev/DebugCommandTest.bundle.js)
   - Command/DebugCommandTest.php

--- a/test/Command/expected-entry_point.output.txt
+++ b/test/Command/expected-entry_point.output.txt
@@ -1,0 +1,13 @@
+File info:
+  - Root: DebugCommandTest.php
+  - Type: Entry Point
+  - Size: 3.38K
+
+Bundle bundled files: (dev/DebugCommandTest.bundle.js)
+  - DebugCommandTest.php
+  - expected.output.txt
+Vendor bundled files: (dev/DebugCommandTest.vendor.js)
+  - None
+
+Dependency tree:
+  - expected.output.txt

--- a/test/Command/expected-entry_point.output.txt
+++ b/test/Command/expected-entry_point.output.txt
@@ -1,13 +1,13 @@
 File info:
-  - Root: DebugCommandTest.php
+  - Root: Command/DebugCommandTest.php
   - Type: Entry Point
-  - Size: 3.38K
+  - Size: 3.59K
 
 Bundle bundled files: (dev/DebugCommandTest.bundle.js)
-  - DebugCommandTest.php
-  - expected.output.txt
+  - Command/DebugCommandTest.php
+  - Command/expected.output.txt
 Vendor bundled files: (dev/DebugCommandTest.vendor.js)
   - None
 
 Dependency tree:
-  - expected.output.txt
+  - Command/expected.output.txt

--- a/test/Command/expected.output.txt
+++ b/test/Command/expected.output.txt
@@ -1,5 +1,5 @@
 Entry points:
-  - src/DebugCommandTest.php
+  - Command/DebugCommandTest.php
 
 Asset files:
   - None

--- a/test/Command/expected.output.txt
+++ b/test/Command/expected.output.txt
@@ -1,0 +1,5 @@
+Entry points:
+  - src/DebugCommandTest.php
+
+Asset files:
+  - None

--- a/test/DependencyInjection/HostnetAssetExtensionTest.php
+++ b/test/DependencyInjection/HostnetAssetExtensionTest.php
@@ -63,6 +63,7 @@ class HostnetAssetExtensionTest extends TestCase
             'hostnet_asset.bundler',
             'hostnet_asset.listener.assets_change',
             'hostnet_asset.command.compile',
+            'hostnet_asset.command.debug',
             'hostnet_asset.twig.extension',
         ], array_keys($container->getDefinitions()));
     }
@@ -93,6 +94,7 @@ class HostnetAssetExtensionTest extends TestCase
             'hostnet_asset.bundler',
             'hostnet_asset.listener.assets_change',
             'hostnet_asset.command.compile',
+            'hostnet_asset.command.debug',
             'hostnet_asset.twig.extension',
         ], array_keys($container->getDefinitions()));
 
@@ -162,6 +164,7 @@ class HostnetAssetExtensionTest extends TestCase
             'hostnet_asset.bundler',
             'hostnet_asset.listener.assets_change',
             'hostnet_asset.command.compile',
+            'hostnet_asset.command.debug',
             'hostnet_asset.twig.extension',
         ], array_keys($container->getDefinitions()));
 
@@ -198,6 +201,7 @@ class HostnetAssetExtensionTest extends TestCase
             'hostnet_asset.bundler',
             'hostnet_asset.listener.assets_change',
             'hostnet_asset.command.compile',
+            'hostnet_asset.command.debug',
             'hostnet_asset.twig.extension',
         ], array_keys($container->getDefinitions()));
 
@@ -234,6 +238,7 @@ class HostnetAssetExtensionTest extends TestCase
             'hostnet_asset.bundler',
             'hostnet_asset.listener.assets_change',
             'hostnet_asset.command.compile',
+            'hostnet_asset.command.debug',
             'hostnet_asset.twig.extension',
         ], array_keys($container->getDefinitions()));
 

--- a/test/Functional/FunctionalTest.php
+++ b/test/Functional/FunctionalTest.php
@@ -50,7 +50,11 @@ class FunctionalTest extends KernelTestCase
         $pipeline->execute($reader, $writer);
 
         self::assertEquals(
-            ['web/dev/require.js', 'web/dev/foo.bundle.js', 'web/dev/foo.vendor.js'],
+            [
+                'web' . DIRECTORY_SEPARATOR . 'dev/require.js',
+                'web' . DIRECTORY_SEPARATOR . 'dev/foo.bundle.js',
+                'web' . DIRECTORY_SEPARATOR . 'dev/foo.vendor.js'
+            ],
             array_keys($writer->files)
         );
     }


### PR DESCRIPTION
Added a debug command to show a detailed overview of what each asset will have for dependencies. It shows for entry points what is in each output file and also shows the dependency tree.

`$ bin/console debug:asset`