### PR TITLE
Made asset change listener trigger on the KernelRequest

### DIFF
--- a/src/DependencyInjection/HostnetAssetExtension.php
+++ b/src/DependencyInjection/HostnetAssetExtension.php
@@ -17,14 +17,9 @@ use Hostnet\Component\Resolver\Config\SimpleConfig;
 use Hostnet\Component\Resolver\FileSystem\FileWriter;
 use Hostnet\Component\Resolver\Import\ImportFinder;
 use Hostnet\Component\Resolver\Import\Nodejs\Executable;
-use Hostnet\Component\Resolver\Plugin\AngularPlugin;
-use Hostnet\Component\Resolver\Plugin\CorePlugin;
-use Hostnet\Component\Resolver\Plugin\LessPlugin;
-use Hostnet\Component\Resolver\Plugin\MinifyPlugin;
 use Hostnet\Component\Resolver\Plugin\PluginActivator;
 use Hostnet\Component\Resolver\Plugin\PluginApi;
 use Hostnet\Component\Resolver\Plugin\PluginInterface;
-use Hostnet\Component\Resolver\Plugin\TsPlugin;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -195,7 +190,7 @@ final class HostnetAssetExtension extends Extension
             new Reference('hostnet_asset.bundler'),
             new Reference('hostnet_asset.config'),
         ]))
-            ->addTag('kernel.event_listener', ['event' => KernelEvents::RESPONSE, 'method' => 'onKernelResponse'])
+            ->addTag('kernel.event_listener', ['event' => KernelEvents::REQUEST, 'method' => 'onKernelRequest'])
             ->setPublic(false);
 
         $container->setDefinition('hostnet_asset.listener.assets_change', $change_listener);

--- a/src/EventListener/AssetsChangeListener.php
+++ b/src/EventListener/AssetsChangeListener.php
@@ -3,14 +3,13 @@ declare(strict_types=1);
 /**
  * @copyright 2017 Hostnet B.V.
  */
-
 namespace Hostnet\Bundle\AssetBundle\EventListener;
 
 use Hostnet\Component\Resolver\Bundler\PipelineBundler;
 use Hostnet\Component\Resolver\Config\ConfigInterface;
 use Hostnet\Component\Resolver\FileSystem\FileReader;
 use Hostnet\Component\Resolver\FileSystem\FileWriter;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 final class AssetsChangeListener
@@ -31,7 +30,7 @@ final class AssetsChangeListener
         $this->config  = $config;
     }
 
-    public function onKernelResponse(FilterResponseEvent $e)
+    public function onKernelRequest(GetResponseEvent $e): void
     {
         // Only trigger on the master request.
         if ($e->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {

--- a/test/DependencyInjection/HostnetAssetExtensionTest.php
+++ b/test/DependencyInjection/HostnetAssetExtensionTest.php
@@ -328,8 +328,8 @@ class HostnetAssetExtensionTest extends TestCase
             ]))
                 ->setPublic(false)
                 ->addTag('kernel.event_listener', [
-                    'event' => KernelEvents::RESPONSE,
-                    'method' => 'onKernelResponse'
+                    'event' => KernelEvents::REQUEST,
+                    'method' => 'onKernelRequest'
                 ]),
             $container->getDefinition('hostnet_asset.listener.assets_change')
         );

--- a/test/EventListener/AssetsChangeListenerTest.php
+++ b/test/EventListener/AssetsChangeListenerTest.php
@@ -13,8 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
@@ -41,7 +40,7 @@ class AssetsChangeListenerTest extends TestCase
         );
     }
 
-    public function testOnKernelResponse()
+    public function testOnKernelRequest()
     {
         $this->config->getProjectRoot()->willReturn(__DIR__);
         $this->config->getEventDispatcher()->willReturn(new EventDispatcher());
@@ -53,9 +52,9 @@ class AssetsChangeListenerTest extends TestCase
         $kernel  = $this->prophesize(HttpKernelInterface::class);
         $request = new Request();
 
-        $e = new FilterResponseEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST, new Response());
+        $e = new GetResponseEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
 
-        $this->assets_change_listener->onKernelResponse($e);
+        $this->assets_change_listener->onKernelRequest($e);
     }
 
     public function testOnKernelResponseSubRequest()
@@ -69,8 +68,8 @@ class AssetsChangeListenerTest extends TestCase
         $kernel  = $this->prophesize(HttpKernelInterface::class);
         $request = new Request();
 
-        $e = new FilterResponseEvent($kernel->reveal(), $request, HttpKernelInterface::SUB_REQUEST, new Response());
+        $e = new GetResponseEvent($kernel->reveal(), $request, HttpKernelInterface::SUB_REQUEST);
 
-        $this->assets_change_listener->onKernelResponse($e);
+        $this->assets_change_listener->onKernelRequest($e);
     }
 }


### PR DESCRIPTION
The twig extension registers the function `asset_url` which adds the file change time to the file. However, if the listener triggers on the `kernel.response` it will build the assets after the twig templates have been rendered.

This results that either the change time will be wrong (from the previous version) or, even worse, an error where the file was missing. So asset compilation should happen earlier, on the `kernel.request`.