### PR TITLE
Added way to see the logging output of the asset compilation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php":                      "^7.1",
-        "hostnet/asset-lib":        "^0.0.7",
+        "hostnet/asset-lib":        "^0.0.8",
         "symfony/framework-bundle": "^3.3",
         "symfony/http-foundation":  "^3.3",
         "symfony/process":          "^3.3"

--- a/src/Command/CompileCommand.php
+++ b/src/Command/CompileCommand.php
@@ -9,9 +9,11 @@ use Hostnet\Component\Resolver\Bundler\PipelineBundler;
 use Hostnet\Component\Resolver\Config\ConfigInterface;
 use Hostnet\Component\Resolver\FileSystem\FileReader;
 use Hostnet\Component\Resolver\FileSystem\FileWriter;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Debug\BufferingLogger;
 
 final class CompileCommand extends Command
 {
@@ -27,12 +29,18 @@ final class CompileCommand extends Command
      */
     private $config;
 
-    public function __construct(PipelineBundler $bundler, ConfigInterface $config)
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(PipelineBundler $bundler, ConfigInterface $config, BufferingLogger $logger)
     {
         parent::__construct('assets:compile');
 
         $this->bundler = $bundler;
         $this->config  = $config;
+        $this->logger  = $logger;
     }
 
     /**
@@ -43,11 +51,41 @@ final class CompileCommand extends Command
         $reader = new FileReader($this->config->getProjectRoot());
         $writer = new FileWriter($this->config->getEventDispatcher(), $this->config->getProjectRoot());
 
+        $start = microtime(true);
+
         $this->bundler->execute($reader, $writer);
+
+        if ($output->getVerbosity() >= OutputInterface::VERBOSITY_VERY_VERBOSE) {
+            $output->writeln('Time: ' . round((microtime(true) - $start) * 1000) . 'ms');
+            $output->writeln('');
+
+            // Output the logs.
+            foreach ($this->logger->cleanLogs() as $line) {
+                if ($line[0] === 'debug' && $output->getVerbosity() < OutputInterface::VERBOSITY_DEBUG) {
+                    continue;
+                }
+
+                $output->writeln($this->interpolate($line[1], $line[2]));
+            }
+        }
 
         // Write this exit message to denote that we are done
         // Is used in a functional way to prevent defunct processes
         // https://github.com/symfony/symfony/issues/12097#issuecomment-343145050
         $output->writeln(self::EXIT_MESSAGE);
+    }
+
+    private function interpolate($message, array $context)
+    {
+        // Build a replacement array with braces around the context keys.
+        $replace = [];
+        foreach ($context as $key => $val) {
+            if (! is_array($val) && (! is_object($val) || method_exists($val, '__toString'))) {
+                $replace[sprintf('{%s}', $key)] = $val;
+            }
+        }
+
+        // Interpolate replacement values into the message and return the result.
+        return strtr($message, $replace);
     }
 }

--- a/src/DependencyInjection/HostnetAssetExtension.php
+++ b/src/DependencyInjection/HostnetAssetExtension.php
@@ -21,6 +21,7 @@ use Hostnet\Component\Resolver\Plugin\PluginActivator;
 use Hostnet\Component\Resolver\Plugin\PluginApi;
 use Hostnet\Component\Resolver\Plugin\PluginInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Debug\BufferingLogger;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -79,7 +80,7 @@ final class HostnetAssetExtension extends Extension
             $plugins,
             new Reference('hostnet_asset.node.executable'),
             new Reference('event_dispatcher'),
-            new Reference('logger')
+            new Reference('hostnet_asset.logger')
         ]))
             ->setPublic(false);
 
@@ -102,7 +103,7 @@ final class HostnetAssetExtension extends Extension
 
         $pipeline = (new Definition(ContentPipeline::class, [
             new Reference('event_dispatcher'),
-            new Reference('logger'),
+            new Reference('hostnet_asset.logger'),
             new Reference('hostnet_asset.config'),
             new Reference('hostnet_asset.file_writer'),
         ]))
@@ -126,7 +127,7 @@ final class HostnetAssetExtension extends Extension
         $bundler = (new Definition(PipelineBundler::class, [
             new Reference('hostnet_asset.import_finder'),
             new Reference('hostnet_asset.pipline'),
-            new Reference('logger'),
+            new Reference('hostnet_asset.logger'),
             new Reference('hostnet_asset.config'),
             new Reference('hostnet_asset.runner'),
         ]))
@@ -140,6 +141,7 @@ final class HostnetAssetExtension extends Extension
         $container->setDefinition('hostnet_asset.plugin.api', $plugin_api);
         $container->setDefinition('hostnet_asset.plugin.activator', $plugin_activator);
         $container->setDefinition('hostnet_asset.bundler', $bundler);
+        $container->setDefinition('hostnet_asset.logger', new Definition(BufferingLogger::class));
 
         // Register event listeners
         $this->configureEventListeners($container);
@@ -163,6 +165,7 @@ final class HostnetAssetExtension extends Extension
         $compile = (new Definition(CompileCommand::class, [
             new Reference('hostnet_asset.bundler'),
             new Reference('hostnet_asset.config'),
+            new Reference('hostnet_asset.logger'),
         ]))
             ->addTag('console.command')
             ->setPublic(false);

--- a/test/Command/CompileCommandTest.php
+++ b/test/Command/CompileCommandTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Debug\BufferingLogger;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
@@ -35,7 +36,8 @@ class CompileCommandTest extends TestCase
 
         $this->compile_command = new CompileCommand(
             $this->bundler->reveal(),
-            $this->config->reveal()
+            $this->config->reveal(),
+            new BufferingLogger()
         );
     }
 
@@ -45,6 +47,9 @@ class CompileCommandTest extends TestCase
         $this->config->getEventDispatcher()->willReturn(new EventDispatcher());
 
         $output = $this->prophesize(OutputInterface::class);
+        $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_VERY_VERBOSE);
+        $output->writeln(Argument::containingString('Time: '))->shouldBeCalled();
+        $output->writeln('')->shouldBeCalled();
 
         $this->bundler
             ->execute(Argument::type(ReaderInterface::class), Argument::type(WriterInterface::class))

--- a/test/DependencyInjection/HostnetAssetExtensionTest.php
+++ b/test/DependencyInjection/HostnetAssetExtensionTest.php
@@ -17,6 +17,7 @@ use Hostnet\Component\Resolver\Plugin\LessPlugin;
 use Hostnet\Component\Resolver\Plugin\TsPlugin;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
+use Symfony\Component\Debug\BufferingLogger;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -61,6 +62,7 @@ class HostnetAssetExtensionTest extends TestCase
             'hostnet_asset.plugin.api',
             'hostnet_asset.plugin.activator',
             'hostnet_asset.bundler',
+            'hostnet_asset.logger',
             'hostnet_asset.listener.assets_change',
             'hostnet_asset.command.compile',
             'hostnet_asset.command.debug',
@@ -92,6 +94,7 @@ class HostnetAssetExtensionTest extends TestCase
             'hostnet_asset.plugin.api',
             'hostnet_asset.plugin.activator',
             'hostnet_asset.bundler',
+            'hostnet_asset.logger',
             'hostnet_asset.listener.assets_change',
             'hostnet_asset.command.compile',
             'hostnet_asset.command.debug',
@@ -127,6 +130,7 @@ class HostnetAssetExtensionTest extends TestCase
             'hostnet_asset.plugin.api',
             'hostnet_asset.plugin.activator',
             'hostnet_asset.bundler',
+            'hostnet_asset.logger',
             'hostnet_asset.command.compile',
             'hostnet_asset.twig.extension',
         ], array_keys($container->getDefinitions()));
@@ -162,6 +166,7 @@ class HostnetAssetExtensionTest extends TestCase
             'hostnet_asset.plugin.api',
             'hostnet_asset.plugin.activator',
             'hostnet_asset.bundler',
+            'hostnet_asset.logger',
             'hostnet_asset.listener.assets_change',
             'hostnet_asset.command.compile',
             'hostnet_asset.command.debug',
@@ -199,6 +204,7 @@ class HostnetAssetExtensionTest extends TestCase
             'hostnet_asset.plugin.api',
             'hostnet_asset.plugin.activator',
             'hostnet_asset.bundler',
+            'hostnet_asset.logger',
             'hostnet_asset.listener.assets_change',
             'hostnet_asset.command.compile',
             'hostnet_asset.command.debug',
@@ -236,6 +242,7 @@ class HostnetAssetExtensionTest extends TestCase
             'hostnet_asset.plugin.api',
             'hostnet_asset.plugin.activator',
             'hostnet_asset.bundler',
+            'hostnet_asset.logger',
             'hostnet_asset.listener.assets_change',
             'hostnet_asset.command.compile',
             'hostnet_asset.command.debug',
@@ -277,7 +284,7 @@ class HostnetAssetExtensionTest extends TestCase
 
         self::assertEquals((new Definition(ContentPipeline::class, [
             new Reference('event_dispatcher'),
-            new Reference('logger'),
+            new Reference('hostnet_asset.logger'),
             new Reference('hostnet_asset.config'),
             new Reference('hostnet_asset.file_writer')
         ]))->setPublic(false), $container->getDefinition('hostnet_asset.pipline'));
@@ -286,7 +293,7 @@ class HostnetAssetExtensionTest extends TestCase
             (new Definition(PipelineBundler::class, [
                 new Reference('hostnet_asset.import_finder'),
                 new Reference('hostnet_asset.pipline'),
-                new Reference('logger'),
+                new Reference('hostnet_asset.logger'),
                 new Reference('hostnet_asset.config'),
                 new Reference('hostnet_asset.runner'),
             ]))
@@ -299,6 +306,7 @@ class HostnetAssetExtensionTest extends TestCase
             (new Definition(CompileCommand::class, [
                 new Reference('hostnet_asset.bundler'),
                 new Reference('hostnet_asset.config'),
+                new Reference('hostnet_asset.logger'),
             ]))
                 ->setPublic(false)
                 ->addTag('console.command'),
@@ -345,7 +353,7 @@ class HostnetAssetExtensionTest extends TestCase
         $container->setParameter('kernel.root_dir', __DIR__);
 
         $container->setDefinition('event_dispatcher', new Definition(EventDispatcher::class));
-        $container->setDefinition('logger', new Definition(NullLogger::class));
+        $container->setDefinition('hostnet_asset.logger', new Definition(BufferingLogger::class));
 
         $this->hostnet_asset_extension->load([[
             'bin' => ['node' => '/usr/bin/node'],


### PR DESCRIPTION
Added way to see the logging output of the asset compilation

You can now pass `-vv` or `-vvv` to show more information when running the compile command.