### PR TITLE
Update minimum Symfony version to 4.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,17 +6,17 @@
     "require": {
         "php":                          ">=7.2",
         "hostnet/asset-lib":            "^0.3.0",
-        "symfony/config":               "^4.0.0",
-        "symfony/console":              "^4.0.0",
-        "symfony/dependency-injection": "^4.0.0",
-        "symfony/http-kernel":          "^4.0.0",
-        "symfony/process":              "^4.0.0"
+        "symfony/config":               "^4.3",
+        "symfony/console":              "^4.3",
+        "symfony/dependency-injection": "^4.3",
+        "symfony/http-kernel":          "^4.3",
+        "symfony/process":              "^4.3"
     },
     "require-dev": {
         "hostnet/phpcs-tool":       "^8.3.3",
         "phpunit/phpunit":          "^8.1.3",
-        "symfony/framework-bundle": "^4.2.8",
-        "symfony/yaml":             "^4.2.8",
+        "symfony/framework-bundle": "^4.3",
+        "symfony/yaml":             "^4.3",
         "twig/twig":                "^2.9.0"
     },
     "autoload": {

--- a/src/Command/CompileCommand.php
+++ b/src/Command/CompileCommand.php
@@ -37,7 +37,7 @@ final class CompileCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         switch ($output->getVerbosity()) {
             case OutputInterface::VERBOSITY_DEBUG:
@@ -73,5 +73,7 @@ final class CompileCommand extends Command
         // Is used in a functional way to prevent defunct processes
         // https://github.com/symfony/symfony/issues/12097#issuecomment-343145050
         $output->writeln(self::EXIT_MESSAGE);
+
+        return 0;
     }
 }

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -28,6 +28,9 @@ class DebugCommand extends Command
         $this->finder = $finder;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     protected function configure(): void
     {
         $this
@@ -35,13 +38,18 @@ class DebugCommand extends Command
             ->addArgument('file');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): void
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
     {
         if ($input->getArgument('file')) {
             $this->checkFile($output, $input->getArgument('file'));
         } else {
             $this->printAll($output);
         }
+
+        return 0;
     }
 
     private function checkFile(OutputInterface $output, string $file): void

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -6,10 +6,8 @@ declare(strict_types=1);
 
 namespace Hostnet\Bundle\AssetBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Process\ExecutableFinder;
 
 final class Configuration implements ConfigurationInterface
@@ -19,9 +17,8 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $finder       = new ExecutableFinder();
-        $tree_builder = $this->createTreeBuilder();
-        $root_node    = $this->retrieveRootNode($tree_builder);
-
+        $tree_builder = new TreeBuilder(self::CONFIG_ROOT);
+        $root_node    = $tree_builder->getRootNode();
         $root_node
             ->children()
                 ->arrayNode('files')
@@ -89,27 +86,5 @@ final class Configuration implements ConfigurationInterface
             ->end();
 
         return $tree_builder;
-    }
-
-    private function createTreeBuilder(): TreeBuilder
-    {
-        if (Kernel::VERSION_ID >= 40200) {
-            return new TreeBuilder(self::CONFIG_ROOT);
-        }
-        if (Kernel::VERSION_ID >= 30300 && Kernel::VERSION_ID < 40200) {
-            return new TreeBuilder();
-        }
-        throw new \RuntimeException('This bundle can only be used by Symfony 3.3 and up.');
-    }
-
-    private function retrieveRootNode(TreeBuilder $tree_builder): NodeDefinition
-    {
-        if (Kernel::VERSION_ID >= 40200) {
-            return $tree_builder->getRootNode();
-        }
-        if (Kernel::VERSION_ID >= 30300 && Kernel::VERSION_ID < 40200) {
-            return $tree_builder->root(self::CONFIG_ROOT);
-        }
-        throw new \RuntimeException('This bundle can only be used by Symfony 3.3 and up.');
     }
 }

--- a/src/EventListener/AssetsChangeListener.php
+++ b/src/EventListener/AssetsChangeListener.php
@@ -8,7 +8,7 @@ namespace Hostnet\Bundle\AssetBundle\EventListener;
 
 use Hostnet\Component\Resolver\Builder\BuildConfig;
 use Hostnet\Component\Resolver\Builder\BundlerInterface;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 final class AssetsChangeListener
@@ -22,7 +22,7 @@ final class AssetsChangeListener
         $this->build_config = $build_config;
     }
 
-    public function onKernelRequest(GetResponseEvent $e): void
+    public function onKernelRequest(RequestEvent $e): void
     {
         // Only trigger on the master request.
         if ($e->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {

--- a/test/DependencyInjection/HostnetAssetExtensionTest.php
+++ b/test/DependencyInjection/HostnetAssetExtensionTest.php
@@ -76,9 +76,7 @@ class HostnetAssetExtensionTest extends TestCase
         $container->setParameter('kernel.project_dir', __DIR__);
         $container->setParameter('kernel.cache_dir', __DIR__);
 
-        $this->hostnet_asset_extension->load([[
-            'bin' => ['node' => '/usr/bin/node'],
-        ]], $container);
+        $this->hostnet_asset_extension->load([['bin' => ['node' => '/usr/bin/node']]], $container);
 
         self::assertEquals([
             'service_container',
@@ -110,9 +108,7 @@ class HostnetAssetExtensionTest extends TestCase
         $container->setParameter('kernel.project_dir', __DIR__);
         $container->setParameter('kernel.cache_dir', __DIR__);
 
-        $this->hostnet_asset_extension->load([[
-            'bin' => ['node' => '/usr/bin/node'],
-        ]], $container);
+        $this->hostnet_asset_extension->load([['bin' => ['node' => '/usr/bin/node']]], $container);
 
         self::assertEquals([
             'service_container',
@@ -142,10 +138,15 @@ class HostnetAssetExtensionTest extends TestCase
         $container->setParameter('kernel.project_dir', __DIR__);
         $container->setParameter('kernel.cache_dir', __DIR__);
 
-        $this->hostnet_asset_extension->load([[
-            'bin' => ['node' => '/usr/bin/node'],
-            'plugins' => [TsPlugin::class => true],
-        ]], $container);
+        $this->hostnet_asset_extension->load(
+            [
+                [
+                    'bin'     => ['node' => '/usr/bin/node'],
+                    'plugins' => [TsPlugin::class => true],
+                ],
+            ],
+            $container
+        );
 
         self::assertEquals([
             'service_container',
@@ -178,10 +179,15 @@ class HostnetAssetExtensionTest extends TestCase
         $container->setParameter('kernel.project_dir', __DIR__);
         $container->setParameter('kernel.cache_dir', __DIR__);
 
-        $this->hostnet_asset_extension->load([[
-            'bin' => ['node' => '/usr/bin/node'],
-            'plugins' => [LessPlugin::class => true],
-        ]], $container);
+        $this->hostnet_asset_extension->load(
+            [
+                [
+                    'bin'     => ['node' => '/usr/bin/node'],
+                    'plugins' => [LessPlugin::class => true],
+                ],
+            ],
+            $container
+        );
 
         self::assertEquals([
             'service_container',
@@ -285,7 +291,7 @@ class HostnetAssetExtensionTest extends TestCase
             ]))
                 ->setPublic(false)
                 ->addTag('kernel.event_listener', [
-                    'event' => KernelEvents::REQUEST,
+                    'event'  => KernelEvents::REQUEST,
                     'method' => 'onKernelRequest',
                 ]),
             $container->getDefinition('hostnet_asset.listener.assets_change')
@@ -304,13 +310,18 @@ class HostnetAssetExtensionTest extends TestCase
         $container->setDefinition('event_dispatcher', new Definition(EventDispatcher::class));
         $container->setDefinition('logger', new Definition(NullLogger::class));
 
-        $this->hostnet_asset_extension->load([[
-            'bin' => ['node' => '/usr/bin/node'],
-            'plugins' => [
-                TsPlugin::class => true,
-                LessPlugin::class => true,
+        $this->hostnet_asset_extension->load(
+            [
+                [
+                    'bin'     => ['node' => '/usr/bin/node'],
+                    'plugins' => [
+                        TsPlugin::class   => true,
+                        LessPlugin::class => true,
+                    ],
+                ],
             ],
-        ]], $container);
+            $container
+        );
 
         $container->compile();
 
@@ -332,10 +343,15 @@ class HostnetAssetExtensionTest extends TestCase
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('stdClass should implement ' . PluginInterface::class);
 
-        $this->hostnet_asset_extension->load([[
-            'bin'     => ['node' => '/usr/bin/node'],
-            'plugins' => [\stdClass::class => true],
-        ]], $container);
+        $this->hostnet_asset_extension->load(
+            [
+                [
+                    'bin'     => ['node' => '/usr/bin/node'],
+                    'plugins' => [\stdClass::class => true],
+                ],
+            ],
+            $container
+        );
     }
 
     public function testBuildNonBuiltin(): void
@@ -350,12 +366,15 @@ class HostnetAssetExtensionTest extends TestCase
         $container->setDefinition('event_dispatcher', new Definition(EventDispatcher::class));
         $container->setDefinition('logger', new Definition(NullLogger::class));
 
-        $this->hostnet_asset_extension->load([[
-            'bin' => ['node' => '/usr/bin/node'],
-            'plugins' => [
-                MockPlugin::class => true,
+        $this->hostnet_asset_extension->load(
+            [
+                [
+                    'bin'     => ['node' => '/usr/bin/node'],
+                    'plugins' => [MockPlugin::class => true],
+                ],
             ],
-        ]], $container);
+            $container
+        );
 
         // make the config public
         $container->getDefinition('hostnet_asset.config')->setPublic(true);

--- a/test/EventListener/AssetsChangeListenerTest.php
+++ b/test/EventListener/AssetsChangeListenerTest.php
@@ -10,7 +10,7 @@ use Hostnet\Component\Resolver\Builder\BuildConfig;
 use Hostnet\Component\Resolver\Builder\BundlerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
@@ -44,7 +44,7 @@ class AssetsChangeListenerTest extends TestCase
         $kernel  = $this->prophesize(HttpKernelInterface::class);
         $request = new Request();
 
-        $e = new GetResponseEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
+        $e = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::MASTER_REQUEST);
 
         $this->assets_change_listener->onKernelRequest($e);
     }
@@ -56,7 +56,7 @@ class AssetsChangeListenerTest extends TestCase
         $kernel  = $this->prophesize(HttpKernelInterface::class);
         $request = new Request();
 
-        $e = new GetResponseEvent($kernel->reveal(), $request, HttpKernelInterface::SUB_REQUEST);
+        $e = new RequestEvent($kernel->reveal(), $request, HttpKernelInterface::SUB_REQUEST);
 
         $this->assets_change_listener->onKernelRequest($e);
     }


### PR DESCRIPTION
Set minimum Symfony version to 4.3 in preparation for Symfony 4.4 | 5.
Resolved Symfony 4.3 deprecations.