### PR TITLE
Upgrade phpcs-tool to 9.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
         "symfony/process":              "^4.3 || ^5.0"
     },
     "require-dev": {
-        "hostnet/phpcs-tool":       "^8.3.3",
+        "hostnet/phpcs-tool":       "^9.0.0",
         "phpspec/prophecy-phpunit": "^2.0.1",
         "phpunit/phpunit":          "^9.5.5",
         "symfony/framework-bundle": "^4.3 || ^5.0",
         "symfony/yaml":             "^4.3 || ^5.0",
-        "twig/twig":                "^2.9.0||^3.0.0"
+        "twig/twig":                "^3.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -28,9 +28,6 @@ class DebugCommand extends Command
         $this->finder = $finder;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function configure(): void
     {
         $this

--- a/test/Command/CompileCommandTest.php
+++ b/test/Command/CompileCommandTest.php
@@ -91,12 +91,14 @@ class CompileCommandTest extends TestCase
         } else {
             $formatter = $this->prophesize(OutputFormatterInterface::class);
             $output->getFormatter()->willReturn($formatter->reveal());
-
         }
         $output->getVerbosity()->willReturn(OutputInterface::VERBOSITY_VERY_VERBOSE);
         $output->writeln(CompileCommand::EXIT_MESSAGE)->shouldBeCalled();
         $output->writeln('')->shouldBeCalled();
-        $output->writeln(' Asset   Size    Status ')->shouldBeCalled();
+
+        // Trailing and leading space change between Symfony versions
+        $output->writeln(Argument::containingString('Asset   Size    Status'))->shouldBeCalled();
+
         $output->writeln(Argument::that(function (string $v) {
             return preg_match('/Total time: \d+ms/i', $v);
         }))->shouldBeCalled();


### PR DESCRIPTION
- Upgrades phpcs-tool to 9.0.0
- End twig/twig:2 support